### PR TITLE
z-index and overflow

### DIFF
--- a/css/layout1.sass
+++ b/css/layout1.sass
@@ -12,9 +12,9 @@ figure
 
 .content
   position: relative
-  z-index: 2
   background: white
   margin-bottom: 400px
+  overflow: hidden
 
   article
     padding: 100px 0
@@ -206,6 +206,7 @@ footer
   position: fixed
   bottom: 0
   width: 100%
+  z-index: -1
 
   .footer-stuff
     max-width: 640px

--- a/css/style.css
+++ b/css/style.css
@@ -868,9 +868,9 @@ figure {
 
 .content {
   position: relative;
-  z-index: 2;
   background: white;
-  margin-bottom: 400px; }
+  margin-bottom: 400px;
+  overflow: hidden; }
   .content article {
     padding: 100px 0;
     max-width: 640px;
@@ -1017,7 +1017,8 @@ footer {
   padding: 40px 0;
   position: fixed;
   bottom: 0;
-  width: 100%; }
+  width: 100%;
+  z-index: -1; }
   footer .footer-stuff {
     max-width: 640px;
     margin: 0 auto; }
@@ -1025,3 +1026,5 @@ footer {
     color: white; }
   footer input {
     color: #666; }
+
+/*# sourceMappingURL=style.css.map */

--- a/css/style.css
+++ b/css/style.css
@@ -1026,3 +1026,4 @@ footer {
     color: white; }
   footer input {
     color: #666; }
+    

--- a/css/style.css
+++ b/css/style.css
@@ -1026,5 +1026,3 @@ footer {
     color: white; }
   footer input {
     color: #666; }
-
-/*# sourceMappingURL=style.css.map */


### PR DESCRIPTION
This PR corrects two things:
- z-index: bird-box wasn't displaying below footer
  It seems better to use z-index only once, on the footer, displaying it below the rest of the content, rather than using z-index on each of the divs which we want to be above. It's better also for future new blocks we create.
  ![z-index](https://cloud.githubusercontent.com/assets/11148232/7811051/82ef478c-03a7-11e5-9802-540af46f24ac.png)
- overflow: the moving blog-posts cards make horizontal scrollbar appear during the transition, making the web not mobile-friendly.
  ![overflow](https://cloud.githubusercontent.com/assets/11148232/7811053/8a909e82-03a7-11e5-8156-10dc733c4e9a.png)
