### PR TITLE
Full-Height-Bird-Box

### DIFF
--- a/css/layout1.sass
+++ b/css/layout1.sass
@@ -35,7 +35,7 @@ img
   height: 600px
   background:
     image: url(../images/bird-bg.jpg)
-    size: auto 600px
+    size: cover
     position: top center
     attachment: fixed
   overflow: hidden

--- a/js/functions.js
+++ b/js/functions.js
@@ -1,4 +1,8 @@
-var pContainerHeight = $('.bird-box').height();
+var $birdbox = $('.bird-box');
+$(function() {
+  $birdbox.css('height', $(window).height());
+});
+var pContainerHeight = $birdbox.height();
 
 $(window).scroll(function(){
 


### PR DESCRIPTION
This is my first time doing a PR, so excuse my mistakes if I have made any!

When I visited the GH-Pages branch on DevTip's Parallax on the Web series, I noticed the .bird-box wasn't the same size as the window height, thus leaving a bit of white space at the bottom which I didn't like, such as the image below:

![screenshot_2](https://cloud.githubusercontent.com/assets/7685469/7922347/71072124-08a3-11e5-8300-d5bc741c88db.png)

These two simple code fixes change that, as it sets .bird-box to the same height as the window in functions.js, and then changes the background-size property value to 'cover'.
