### PR TITLE
Removed redundant jQuery selector

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -25,9 +25,9 @@ $(window).scroll(function(){
   if(wScroll > $('.clothes-pics').offset().top - ($(window).height() / 1.2)) {
 
     $('.clothes-pics figure').each(function(i){
-
+      var figure = $(this);
       setTimeout(function(){
-        $('.clothes-pics figure').eq(i).addClass('is-showing');
+        figure.addClass('is-showing');
       }, (700 * (Math.exp(i * 0.14))) - 700);
     });
 


### PR DESCRIPTION
When inside of the $('.clothes-pics figure').each loop, you can use $(this) to grab the current item.  No need to do another query using $('.clothes-pics figure').eq(i).

As a programmer, I cringed a little when I saw this in the video :stuck_out_tongue:

Thanks for the kick ass videos!
