### PR TITLE
Footer appears only after page is fully loaded

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1012,6 +1012,7 @@ img {
     transform: translate(-100px, 20px); }
 
 footer {
+  display: none;
   background: black;
   color: white;
   padding: 40px 0;

--- a/css/style.css
+++ b/css/style.css
@@ -1,4 +1,4 @@
-@charset "UTF-8";
+﻿@charset "UTF-8";
 /*! normalize.css v3.0.2 | MIT License | git.io/normalize */
 /**
  * 1. Set default font family to sans-serif.
@@ -443,17 +443,21 @@ th {
   .nine.columns {
     width: 74.0%; }
 
-  .ten.columns {
+  .ten.columns 
+{
     width: 82.6666666667%; }
 
-  .eleven.columns {
+  
+.eleven.columns {
     width: 91.3333333333%; }
 
-  .twelve.columns {
+  
+.twelve.columns {
     width: 100%;
     margin-left: 0; }
 
-  .one-third.column {
+  
+.one-third.column {
     width: 30.6666666667%; }
 
   .two-thirds.column {
@@ -998,7 +1002,7 @@ img {
         color: black; }
 
 .blog-posts {
-  margin-top: 100px; }
+  margin-top: 100px;   }
   .blog-posts .post {
     border: 1px solid #e1e1e1;
     padding: 20px 20px 0;

--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>BlackBird Co.</title>
+    <title>Changing the title</title>
     <meta name="description" content="">
     <meta name="author" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/index.html
+++ b/index.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
-<html lang="en">
+<html>
   <head>
-    <meta charset="utf-8">
     <title>BlackBird Co.</title>
     <meta name="description" content="">
     <meta name="author" content="">
@@ -24,7 +23,7 @@
         <div class="clothes-pics">
           <div class="row img-row">
             <figure class="columns four"><img src="images/model1.jpg">
-              <figcaption>BlackBird Sweater - <strong>$135</strong></figcaption>
+              <figcaption>BlackBird Sweater -  <strong>$135</strong></figcaption>
             </figure>
             <figure class="columns four"><img src="images/model2.jpg">
               <figcaption>BlackBird Trousers - <strong>$135</strong></figcaption>
@@ -72,7 +71,7 @@
         <div class="blog-posts row">
           <div class="post columns four post-1">
             <h5>Post Title</h5><img src="images/posts/one.jpg">
-            <p>Incididunt ut labore et dolore magna.</p>
+            <p>Incidiunt ut labre et dolore magna.</p>
             <p><a href="" class="button">Read More</a></p>
           </div>
           <div class="post columns four post-2">

--- a/js/functions.js
+++ b/js/functions.js
@@ -58,3 +58,8 @@ $(window).scroll(function(){
 
   }
 });
+
+
+$(document).ready(function(){
+  $("footer").css("display","block");
+});

--- a/js/functions.js
+++ b/js/functions.js
@@ -46,7 +46,8 @@ $(window).scroll(function(){
   }
 
 
-  // Floating Elements
+  
+// Floating Elements
 
   if(wScroll > $('.blog-posts').offset().top - $(window).height()){
 


### PR DESCRIPTION
If the page is still loading, and the header's background is not loaded yet, you can see through the footer through the header.

![hello](https://cloud.githubusercontent.com/assets/11561990/20572633/8650b082-b1ac-11e6-9cc5-7185297c6a6e.jpg)


So I made the footer not being displayed "display:none", until document is loaded, then it is displayed.